### PR TITLE
Decouple: project card pills from ProjectCard

### DIFF
--- a/components/ProjectCard/ProjectCard.tsx
+++ b/components/ProjectCard/ProjectCard.tsx
@@ -1,15 +1,15 @@
-import Link from 'next/link'
-import React from 'react'
+import ProjectCardPills from '~/components/ProjectCard/ProjectCardPills'
 import { WithIntlProps, defineMessages } from 'react-intl'
-import styled from 'styled-components'
-import { Page, PageAs, Color } from '~/common'
-import { APP_URL } from '~/common/constants'
-import Icon from '~/components/Icon'
-import { withIntl } from '~/lib/intl'
 import { formatDisponibility } from '~/lib/project/utils'
 import { pushToDataLayer } from '~/lib/tag-manager'
 import { Project } from '~/redux/ducks/project'
-import Tooltip from '../Tooltip'
+import { Page, PageAs, Color } from '~/common'
+import { APP_URL } from '~/common/constants'
+import styled from 'styled-components'
+import { withIntl } from '~/lib/intl'
+import Icon from '~/components/Icon'
+import Link from 'next/link'
+import React from 'react'
 
 const Container = styled.div`
   background: none;
@@ -87,12 +87,6 @@ const Counter = styled.div`
   > span {
     display: inline-block;
   }
-`
-
-const Pills = styled.div`
-  position: absolute;
-  right: 8px;
-  bottom: 8px;
 `
 
 const Pill = styled.span`
@@ -224,17 +218,7 @@ class ProjectCard extends React.Component<
               />
               <span>{appliedCount}</span>
             </Counter>
-            <Pills>
-              {disponibility &&
-                disponibility.type === 'work' &&
-                disponibility.work.can_be_done_remotely && (
-                  <Tooltip value="Pode ser feito à distância">
-                    <Pill className="pill-secondary t-nowrap">
-                      <Icon name="public" />
-                    </Pill>
-                  </Tooltip>
-                )}
-            </Pills>
+            <ProjectCardPills {...this.props} />
           </Header>,
         )}
         <Author className="truncate">

--- a/components/ProjectCard/ProjectCardPills.tsx
+++ b/components/ProjectCard/ProjectCardPills.tsx
@@ -1,0 +1,31 @@
+import { styles } from '~/components/ProjectCard/ProjectCard.tsx'
+import Tooltip from '~/components/Tooltip'
+import styled from 'styled-components'
+import Icon from '~/components/Icon'
+import React from 'react'
+
+const Pills = styled.div`
+  position: absolute;
+  right: 8px;
+  bottom: 8px;
+`
+
+const ProjectCardPills = ({ disponibility }) => {
+  const { Pill } = styles
+
+  return (
+    <Pills>
+      {disponibility &&
+        disponibility.type === 'work' &&
+        disponibility.work.can_be_done_remotely && (
+          <Tooltip value="Pode ser feito à distância">
+            <Pill className="pill-secondary t-nowrap">
+              <Icon name="public" />
+            </Pill>
+          </Tooltip>
+        )}
+    </Pills>
+  )
+}
+
+export default ProjectCardPills

--- a/core/config/package.json
+++ b/core/config/package.json
@@ -65,7 +65,7 @@
     "formik": "^1.5.3",
     "geoip-lite": "^1.3.8",
     "glob": "^7.1.6",
-    "google-map-react": "^1.1.4",
+    "google-map-react": "1.1.5",
     "graphql": "^14.2.1",
     "graphql-tag": "^2.10.1",
     "immutable": "^4.0.0-rc.12",


### PR DESCRIPTION
Decouple project card pills from ProjectCard to overwrite on channel default (atados)